### PR TITLE
🔒 [security fix] Secure cache directory permissions

### DIFF
--- a/src/data_manager.py
+++ b/src/data_manager.py
@@ -222,7 +222,7 @@ class GameDataManager:
         Persist compiled ruleset data to a JSON cache file.
         """
         try:
-            os.makedirs(self._cache_dir, exist_ok=True)
+            os.makedirs(self._cache_dir, mode=0o700, exist_ok=True)
             path = self._get_cache_path(cache_key)
             data = {
                 "items": self.items,

--- a/src/main.py
+++ b/src/main.py
@@ -194,7 +194,7 @@ class App(ctk.CTk):
             for soldier in self.soldiers:
                 if soldier.id == sid:
                     return soldier
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             pass
         return None
 

--- a/src/main.py
+++ b/src/main.py
@@ -194,7 +194,7 @@ class App(ctk.CTk):
             for soldier in self.soldiers:
                 if soldier.id == sid:
                     return soldier
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             pass
         return None
 

--- a/src/main.py
+++ b/src/main.py
@@ -194,7 +194,9 @@ class App(ctk.CTk):
             for soldier in self.soldiers:
                 if soldier.id == sid:
                     return soldier
-        except (ValueError, TypeError):
+        except ValueError:
+            pass
+        except TypeError:
             pass
         return None
 

--- a/src/views/settings_view.py
+++ b/src/views/settings_view.py
@@ -100,7 +100,7 @@ class SettingsView(ctk.CTkToplevel):
     def open_cache_dir(self):
         cache_dir = self.controller.data_manager._cache_dir
         try:
-            os.makedirs(cache_dir, exist_ok=True)
+            os.makedirs(cache_dir, mode=0o700, exist_ok=True)
             if sys.platform == "win32":
                 os.startfile(cache_dir)
             elif sys.platform == "darwin":

--- a/test/test_base_view.py
+++ b/test/test_base_view.py
@@ -159,48 +159,63 @@ class DummyScrollbar:
         pass
 
 
-mock_ctk = MagicMock()
-mock_ctk.CTkFrame = DummyCTkFrame
-mock_ctk.CTkLabel = DummyCTkLabel
-mock_ctk.CTkButton = DummyCTkButton
-mock_ctk.CTkOptionMenu = DummyCTkOptionMenu
-mock_ctk.CTkTabview = DummyCTkTabview
-mock_ctk.CTkScrollableFrame = DummyCTkScrollableFrame
-mock_ctk.CTkFont = MagicMock()
-
-_original_modules = {
-    "customtkinter": sys.modules.get("customtkinter"),
-    "tkinter": sys.modules.get("tkinter"),
-    "tkinter.ttk": sys.modules.get("tkinter.ttk"),
-}
-
-sys.modules["customtkinter"] = mock_ctk
-
-# Mock ttk
-mock_ttk = MagicMock()
-mock_ttk.Treeview = DummyTreeview
-mock_ttk.Scrollbar = DummyScrollbar
-sys.modules["tkinter"] = MagicMock()
-sys.modules["tkinter"].ttk = mock_ttk
-sys.modules["tkinter.ttk"] = mock_ttk
-
-# Now import the class under test
-from views.base_view import BaseView  # noqa: E402
-
-
-def tearDownModule():
-    """Restore sys.modules to prevent test pollution."""
-    for mod_name, original_mod in _original_modules.items():
-        if original_mod is None:
-            sys.modules.pop(mod_name, None)
-        else:
-            sys.modules[mod_name] = original_mod
-
-    # Remove the imported module so it can be cleanly re-imported by other tests
-    sys.modules.pop("views.base_view", None)
+# Global BaseView that will be populated in setUpClass
+BaseView = None
 
 
 class TestBaseView(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Setup mocks for the entire class."""
+        cls._original_modules = {
+            "customtkinter": sys.modules.get("customtkinter"),
+            "tkinter": sys.modules.get("tkinter"),
+            "tkinter.ttk": sys.modules.get("tkinter.ttk"),
+            "PIL": sys.modules.get("PIL"),
+            "PIL.Image": sys.modules.get("PIL.Image"),
+        }
+
+        mock_ctk = MagicMock()
+        mock_ctk.CTkFrame = DummyCTkFrame
+        mock_ctk.CTkLabel = DummyCTkLabel
+        mock_ctk.CTkButton = DummyCTkButton
+        mock_ctk.CTkOptionMenu = DummyCTkOptionMenu
+        mock_ctk.CTkTabview = DummyCTkTabview
+        mock_ctk.CTkScrollableFrame = DummyCTkScrollableFrame
+        mock_ctk.CTkFont = MagicMock()
+        sys.modules["customtkinter"] = mock_ctk
+
+        mock_ttk = MagicMock()
+        mock_ttk.Treeview = DummyTreeview
+        mock_ttk.Scrollbar = DummyScrollbar
+        sys.modules["tkinter"] = MagicMock()
+        sys.modules["tkinter"].ttk = mock_ttk
+        sys.modules["tkinter.ttk"] = mock_ttk
+
+        sys.modules["PIL"] = MagicMock()
+        sys.modules["PIL.Image"] = MagicMock()
+
+        # Ensure views.base_view is reloaded with these mocks
+        if "views.base_view" in sys.modules:
+            del sys.modules["views.base_view"]
+
+        import views.base_view
+
+        global BaseView
+        BaseView = views.base_view.BaseView
+
+    @classmethod
+    def tearDownClass(cls):
+        """Restore sys.modules to prevent test pollution."""
+        for mod_name, original_mod in cls._original_modules.items():
+            if original_mod is None:
+                sys.modules.pop(mod_name, None)
+            else:
+                sys.modules[mod_name] = original_mod
+
+        # Remove the imported module so it can be cleanly re-imported by other tests
+        sys.modules.pop("views.base_view", None)
+
     def setUp(self):
         self.mock_parent = MagicMock()
         self.mock_controller = MagicMock()

--- a/test/test_security_makedirs.py
+++ b/test/test_security_makedirs.py
@@ -30,8 +30,17 @@ class DummyCTkToplevel(DummyCTk):
 
 ctk_mock = MagicMock()
 ctk_mock.CTkToplevel = DummyCTkToplevel
-sys.modules["customtkinter"] = ctk_mock
 
+_original_modules = {
+    "customtkinter": sys.modules.get("customtkinter"),
+    "tkinter": sys.modules.get("tkinter"),
+    "tkinter.filedialog": sys.modules.get("tkinter.filedialog"),
+    "tkinter.messagebox": sys.modules.get("tkinter.messagebox"),
+    "PIL": sys.modules.get("PIL"),
+    "PIL.Image": sys.modules.get("PIL.Image"),
+}
+
+sys.modules["customtkinter"] = ctk_mock
 sys.modules["tkinter"] = MagicMock()
 sys.modules["tkinter.filedialog"] = MagicMock()
 sys.modules["tkinter.messagebox"] = MagicMock()
@@ -40,6 +49,19 @@ sys.modules["PIL.Image"] = MagicMock()
 
 from src.data_manager import GameDataManager  # noqa: E402
 from src.views.settings_view import SettingsView  # noqa: E402
+
+
+def tearDownModule():
+    """Restore sys.modules to prevent test pollution."""
+    for mod_name, original_mod in _original_modules.items():
+        if original_mod is None:
+            sys.modules.pop(mod_name, None)
+        else:
+            sys.modules[mod_name] = original_mod
+
+    # Remove the imported module so it can be cleanly re-imported by other tests
+    sys.modules.pop("src.data_manager", None)
+    sys.modules.pop("src.views.settings_view", None)
 
 
 class TestSecurityMakedirs(unittest.TestCase):

--- a/test/test_security_makedirs.py
+++ b/test/test_security_makedirs.py
@@ -1,0 +1,99 @@
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Add src to path
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+
+# Mock tkinter and customtkinter and other GUI stuff before importing SettingsView
+class DummyCTk:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def title(self, *args, **kwargs):
+        pass
+
+    def geometry(self, *args, **kwargs):
+        pass
+
+    def mainloop(self, *args, **kwargs):
+        pass
+
+
+class DummyCTkToplevel(DummyCTk):
+    pass
+
+
+ctk_mock = MagicMock()
+ctk_mock.CTkToplevel = DummyCTkToplevel
+sys.modules["customtkinter"] = ctk_mock
+
+sys.modules["tkinter"] = MagicMock()
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["PIL"] = MagicMock()
+sys.modules["PIL.Image"] = MagicMock()
+
+from src.data_manager import GameDataManager  # noqa: E402
+from src.views.settings_view import SettingsView  # noqa: E402
+
+
+class TestSecurityMakedirs(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_cache_dir_permissions_data_manager(self):
+        # We need to mock the _cache_dir to point to our test_dir
+        dm = GameDataManager("/fake/path")
+        test_cache_dir = os.path.join(self.test_dir, "cache_dm")
+        dm._cache_dir = test_cache_dir
+
+        # Call _save_cache (it will likely fail on save but we care about makedirs)
+        dm._save_cache("test_key")
+
+        self.assertTrue(os.path.exists(test_cache_dir))
+        mode = os.stat(test_cache_dir).st_mode
+        import stat
+
+        perm = stat.S_IMODE(mode)
+
+        self.assertEqual(
+            oct(perm), "0o700", f"Expected permissions 0700, got {oct(perm)}"
+        )
+
+    @patch("src.views.settings_view.subprocess.Popen")
+    @patch("src.views.settings_view.os.startfile", create=True)
+    def test_cache_dir_permissions_settings_view(self, mock_startfile, mock_popen):
+        # Mock controller and data_manager
+        mock_controller = MagicMock()
+        test_cache_dir = os.path.join(self.test_dir, "cache_view")
+        mock_controller.data_manager._cache_dir = test_cache_dir
+
+        # Instantiate SettingsView
+        # We use __new__ to avoid __init__ which calls many GUI things
+        view = SettingsView.__new__(SettingsView)
+        view.controller = mock_controller
+
+        # Call open_cache_dir
+        view.open_cache_dir()
+
+        self.assertTrue(os.path.exists(test_cache_dir))
+        mode = os.stat(test_cache_dir).st_mode
+        import stat
+
+        perm = stat.S_IMODE(mode)
+
+        self.assertEqual(
+            oct(perm), "0o700", f"Expected permissions 0700, got {oct(perm)}"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Secured the creation of the application's cache directory by explicitly setting restrictive permissions (`0700`).
⚠️ **Risk:** Previously, the cache directory was created using the system's default umask (often resulting in `0775` or `0755`), which could allow other local users on the same system to read or write to the cached ruleset data.
🛡️ **Solution:** Added `mode=0o700` to all `os.makedirs` calls responsible for creating the cache directory in `src/data_manager.py` and `src/views/settings_view.py`.

---
*PR created automatically by Jules for task [12092426647400984024](https://jules.google.com/task/12092426647400984024) started by @dealien*